### PR TITLE
  feat: #8 firebase의 auth객체를 활용하여 로그인 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.22.1",
     "react-scripts": "5.0.1",
+    "react-toastify": "^10.0.4",
     "typescript": "^4.4.2",
     "web-vitals": "^2.1.0"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,36 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { app } from 'firebaseApp';
-import { getAuth } from 'firebase/auth';
+import { getAuth, onAuthStateChanged } from 'firebase/auth';
+import { ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 
 import Router from './components/Router';
+import Loader from 'components/Loader';
 
 function App() {
     const auth = getAuth(app);
-    //auth 속성 중에 currentUser가 null이면 로그인 하지 않음을 나타낸다.
+    // auth를 체크하기 전에 (initialize 전)에는 loader를 띄워주는 용도
+    const [init, setInit] = useState<boolean>(false);
+    // auth의 currentUser가 있으면 authenticated로 변경
     const [isAuthenticated, setIsAuthenticated] = useState<boolean>(!!auth?.currentUser);
-    return <Router isAuthenticated={isAuthenticated} />;
-    //true false로 반환
+
+    useEffect(() => {
+        onAuthStateChanged(auth, (user) => {
+            if (user) {
+                setIsAuthenticated(true);
+            } else {
+                setIsAuthenticated(false);
+            }
+            setInit(true);
+        });
+    }, [auth]);
+
+    return (
+        <>
+            <ToastContainer />
+            {init ? <Router isAuthenticated={isAuthenticated} /> : <Loader />}
+        </>
+    );
 }
 
 export default App;

--- a/src/components/Loader.tsx
+++ b/src/components/Loader.tsx
@@ -1,0 +1,3 @@
+export default function Loader() {
+    return <div className="loader" />;
+}

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 import { Link, useNavigate } from 'react-router-dom';
-// import { toast } from 'react-toastify';
+import { toast } from 'react-toastify';
 import { app } from 'firebaseApp';
 import { getAuth, signInWithEmailAndPassword } from 'firebase/auth';
 
@@ -18,10 +18,10 @@ export default function LoginForm() {
             const auth = getAuth(app);
             await signInWithEmailAndPassword(auth, email, password);
 
-            // toast.success('로그인에 성공했습니다.');
+            toast.success('로그인에 성공했습니다.');
             navigate('/');
         } catch (error: any) {
-            // toast.error(error?.code);
+            toast.error(error?.code);
             console.log(error);
         }
     };

--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -1,23 +1,18 @@
-import { useState } from 'react';
 import { Route, Routes, Navigate } from 'react-router-dom';
-import Home from '../pages/home';
-import PostList from '../pages/posts';
-import PostDetail from '../pages/posts/detail';
-import PostNew from '../pages/posts/new';
-import PostEdit from '../pages/posts/edit';
-import ProfilePage from '../pages/profile';
-import SignupPage from '../pages/signup';
-import LoginPage from '../pages/login';
+import Home from 'pages/home';
+import PostList from 'pages/posts';
+import PostDetail from 'pages/posts/detail';
+import PostNew from 'pages/posts/new';
+import PostEdit from 'pages/posts/edit';
+import ProfilePage from 'pages/profile';
+import LoginPage from 'pages/login';
+import SignupPage from 'pages/signup';
 
 interface RouterProps {
     isAuthenticated: boolean;
 }
 
 export default function Router({ isAuthenticated }: RouterProps) {
-    //firebase Auth가 인증되었으면 true로 변경해주는 로직 추가
-
-    // const [isAuthenticated, setIsAuthenticated] = useState<boolean>(false);
-
     return (
         <>
             <Routes>
@@ -29,9 +24,7 @@ export default function Router({ isAuthenticated }: RouterProps) {
                         <Route path="/posts/new" element={<PostNew />} />
                         <Route path="/posts/edit/:id" element={<PostEdit />} />
                         <Route path="/profile" element={<ProfilePage />} />
-                        <Route path="/login" element={<LoginPage />} />
-                        <Route path="/signup" element={<SignupPage />} />
-                        <Route path="/*" element={<Navigate replace to="/" />} />
+                        <Route path="*" element={<Navigate replace to="/" />} />
                     </>
                 ) : (
                     <>

--- a/src/components/SingupForm.tsx
+++ b/src/components/SingupForm.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { app } from 'firebaseApp';
 import { getAuth, createUserWithEmailAndPassword } from 'firebase/auth';
-// import { toast } from 'react-toastify';
+import { toast } from 'react-toastify';
 
 export default function SignupForm() {
     const [error, setError] = useState<string>('');
@@ -18,11 +18,11 @@ export default function SignupForm() {
             const auth = getAuth(app);
             await createUserWithEmailAndPassword(auth, email, password);
 
-            // toast.success('회원가입에 성공했습니다.');
+            toast.success('회원가입에 성공했습니다.');
             navigate('/');
         } catch (error: any) {
             console.log(error);
-            // toast.error(error?.code);
+            toast.error(error?.code);
         }
     };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3761,6 +3761,11 @@ cliui@^8.0.1:
     strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
 
+clsx@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.0.tgz#e851283bcb5c80ee7608db18487433f7b23f77cb"
+  integrity sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -8527,6 +8532,13 @@ react-scripts@5.0.1:
     workbox-webpack-plugin "^6.4.1"
   optionalDependencies:
     fsevents "^2.3.2"
+
+react-toastify@^10.0.4:
+  version "10.0.4"
+  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-10.0.4.tgz#6ecdbbf923a07fc45850e69b0566efc7bf733283"
+  integrity sha512-etR3RgueY8pe88SA67wLm8rJmL1h+CLqUGHuAoNsseW35oTGJEri6eBTyaXnFKNQ80v/eO10hBYLgz036XRGgA==
+  dependencies:
+    clsx "^2.1.0"
 
 react@^18.2.0:
   version "18.2.0"


### PR DESCRIPTION
             



         
- ### 요약

- firebase의 auth를 사용하여 로그인과 회원가입 페이지 구현

### 변경사항

            - 로그인 페이지 구현
            - 회원가입 페이지 구현
            - Loader 및 toast 설치 및 구현

### 테스트 방법 (Optional)

### 스크린샷 or 동영상 (Op


### 참고자료 (Optional)

Resolves #8     
Closes #8  