### PR TITLE
Firestore에서 가져온 데이터로 상세 페이지 구현

### DIFF
--- a/src/components/PostDetail.tsx
+++ b/src/components/PostDetail.tsx
@@ -1,32 +1,55 @@
-import { Link } from 'react-router-dom';
+import { useState, useEffect } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { PostProps } from './PostList';
+import { doc, getDoc } from 'firebase/firestore';
+import { db } from 'firebaseApp';
+import Loader from './Loader';
 
 export default function PostDetail() {
+    const [post, setPost] = useState<PostProps | null>(null);
+    const params = useParams();
+
+    const getPost = async (id: string) => {
+        if (id) {
+            const docRef = doc(db, 'posts', id);
+            const docSnap = await getDoc(docRef);
+
+            setPost({ id: docSnap.id, ...(docSnap.data() as PostProps) });
+        }
+    };
+
+    const handleDelete = () => {
+        console.log('delete!');
+    };
+
+    useEffect(() => {
+        if (params?.id) getPost(params?.id);
+    }, [params?.id]);
+
     return (
         <>
             <div className="post__detail">
-                <div className="post__box">
-                    <div className="post__title">Lorem ipsum</div>
-                </div>
-                <div className="post__profile-box">
-                    <div className="post__profile" />
-                    <div className="post__author-name"> fastcampust</div>
-                    <div className="post__date">2024.03.04 월요일</div>
-                </div>
-                <div className="post__title">게시글</div>
-                <div className="post__utils-box">
-                    <div className="post__delete">삭제</div>
-                    <div className="post__edit">
-                        <Link to={`/posts/edit/1`}>수정</Link>
+                {post ? (
+                    <div className="post__box">
+                        <div className="post__title">{post?.title}</div>
+                        <div className="post__profile-box">
+                            <div className="post__profile" />
+                            <div className="post__author-name">{post?.email}</div>
+                            <div className="post__date">{post?.createdAt}</div>
+                        </div>
+                        <div className="post__utils-box">
+                            <div className="post__delete" role="presentation" onClick={handleDelete}>
+                                삭제
+                            </div>
+                            <div className="post__edit">
+                                <Link to={`/posts/edit/1`}>수정</Link>
+                            </div>
+                        </div>
+                        <div className="post__text post__text--pre-wrap">{post?.content}</div>
                     </div>
-                </div>
-                <div className="post__text">
-                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the
-                    industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type
-                    and scrambled it to make a type specimen book. It has survived not only five centuries, but also the
-                    leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s
-                    with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop
-                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.
-                </div>
+                ) : (
+                    <Loader />
+                )}
             </div>
         </>
     );

--- a/src/components/PostList.tsx
+++ b/src/components/PostList.tsx
@@ -1,4 +1,7 @@
-import { useState } from 'react';
+import AuthContext from 'context/AuthContext';
+import { collection, getDocs } from 'firebase/firestore';
+import { db } from 'firebaseApp';
+import { useContext, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 
 interface PostListProps {
@@ -7,8 +10,32 @@ interface PostListProps {
 
 type TabType = 'all' | 'my';
 
+export interface PostProps {
+    id?: string;
+    title: string;
+    email: string;
+    summary: string;
+    content: string;
+    createdAt: string;
+}
+
 export default function PostList({ hasNavigation = true }: PostListProps) {
     const [activeTab, setActiveTab] = useState<TabType>('all');
+    const [posts, setPosts] = useState<PostProps[]>([]);
+    const { user } = useContext(AuthContext);
+
+    const getPosts = async () => {
+        const datas = await getDocs(collection(db, 'posts'));
+
+        datas?.forEach((doc) => {
+            const dataObj = { ...doc.data(), id: doc.id };
+            setPosts((prev) => [...prev, dataObj as PostProps]);
+        });
+    };
+
+    useEffect(() => {
+        getPosts();
+    }, []);
 
     return (
         <>
@@ -31,34 +58,31 @@ export default function PostList({ hasNavigation = true }: PostListProps) {
                 </div>
             )}
             <div className="post__list">
-                {[...Array(10)].map((e, index) => (
-                    <div key={index} className="post__box">
-                        <Link to={`/posts/${index}`}>
-                            <div className="post__profile-box">
-                                <div className="post__profile" />
-                                <div className="post__author-name">패스트캠퍼스</div>
-                                <div className="post__date">2023.07.08 토요일</div>
-                            </div>
-                            <div className="post__title">게시글 {index}</div>
-                            <div className="post__text">
-                                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eget pretium nunc. Duis
-                                sed arcu eget leo maximus fermentum vel ut risus. Morbi quis enim consequat, venenatis
-                                mauris a, bibendum justo. Vestibulum eros risus, feugiat eget auctor et, lacinia in
-                                quam. Pellentesque pellentesque nunc ultricies nulla convallis finibus. Nulla interdum
-                                laoreet ex, id euismod arcu. Vestibulum pulvinar sem dolor, in laoreet nunc faucibus eu.
-                                Suspendisse convallis vehicula turpis ut dignissim. Sed nec turpis suscipit, ultricies
-                                nisi non, ullamcorper diam. Duis non ullamcorper enim. Suspendisse egestas lorem sed
-                                enim gravida, sit amet ultricies ligula dignissim. Praesent nec consequat est. Praesent
-                                interdum blandit dolor, a dapibus erat gravida ut. Maecenas blandit diam est, ut viverra
-                                augue faucibus ut. Curabitur varius vestibulum erat sit amet malesuada.
-                            </div>
-                            <div className="post__utils-box">
-                                <div className="post__delete">삭제</div>
-                                <div className="post__edit">수정</div>
-                            </div>
-                        </Link>
-                    </div>
-                ))}
+                {posts?.length > 0 ? (
+                    posts?.map((post, index) => (
+                        <div key={post?.id} className="post__box">
+                            <Link to={`/posts/${post?.id}`}>
+                                <div className="post__profile-box">
+                                    <div className="post__profile" />
+                                    <div className="post__author-name">{post?.email}</div>
+                                    <div className="post__date">{post?.createdAt}</div>
+                                </div>
+                                <div className="post__title">{post?.title}</div>
+                                <div className="post__text">{post?.summary}</div>
+                            </Link>
+                            {post?.email === user?.email && (
+                                <div className="post__utils-box">
+                                    <div className="post__delete">삭제</div>
+                                    <Link to={`/posts/edit/${post?.id}`} className="post__edit">
+                                        수정
+                                    </Link>
+                                </div>
+                            )}
+                        </div>
+                    ))
+                ) : (
+                    <div className="post__no-post">게시글이 없습니다.</div>
+                )}
             </div>
         </>
     );

--- a/src/index.css
+++ b/src/index.css
@@ -161,6 +161,14 @@ footer a:hover {
     color: gray;
 }
 
+.post__no-post {
+    padding: 24px;
+    text-align: center;
+    color: gray;
+    border: 1px solid #f2f2f2;
+    border-radius: 20px;
+}
+
 /* post detail */
 
 .post__detail .post__title {
@@ -181,6 +189,10 @@ footer a:hover {
 
 .post__detail .post__text {
     padding: 20px 0px;
+}
+
+.post__text--pre-wrap {
+    white-space: pre-wrap;
 }
 
 /* profile */


### PR DESCRIPTION

- ### 요약

-  Firestore 자체 DB에 저장한 데이터를 가져와 상세 페이지에 뿌려준다

### 변경사항

  - postList에서 row를 클릭 시 db에서 데이터를 가져온다
  - row params id와 db의 데이터에 맞게 postDetail 페이지 구현   

### 테스트 방법 (Optional)

### 스크린샷 or 동영상 (Op


### 참고자료 (Optional)

Resolves #15     
Closes #15 